### PR TITLE
Improved Datalust SEQ Target

### DIFF
--- a/source/include/Seq.ps1
+++ b/source/include/Seq.ps1
@@ -12,32 +12,92 @@
             [hashtable] $Log,
             [hashtable] $Configuration
         )
-
-        $Body = @{
-            "@t"       = $Log.TimestampUtc
-            "@l"       = $Log.Level.substring(0,1).toupper()+$Log.Level.substring(1).tolower()
-            "@m"       = $Log.Message
-            "@mt"      = $Log.RawMessage
-        }
-
-        if ($Log.ExecInfo) {
-            $Body["@x"] = $Log.ExecInfo.ScriptStackTrace
-        }
-
-        $Body += $Log
-
+    
+        $allProperties = @{}
         if($null -ne $Configuration.Properties)
         {
-            $Body += $Configuration.Properties
+            $allProperties += $Configuration.Properties
         }
+
+        # use all properies from log
+        $allProperties += $Log
+        
+        # remove not needed values (dont need to safe data twice)
+        $allProperties.Remove("args")
+        $allProperties.Remove("message")
+        $allProperties.Remove("level")
+        $allProperties.Remove("levelno")
+        $allProperties.Remove("rawmessage")
+        $allProperties.Remove("timestamp")
+        $allProperties.Remove("timestamputc")
+        $allProperties.Remove("execinfo")
+
+        # default use the already parsed message
+        $messageTemplate = $Log.Message
+
+        # check if there are any args given
+        if ($Log.args.count -gt 0) {
+            # args are given, use the raw message with {...} text
+            $messageTemplate = $Log.RawMessage;
+
+            # check if labels are given (same amount of labels are args are necessary)
+            $labels_given = ($null -ne $Log.body.labels -and $Log.args.count -eq $Log.body.labels.count)
+
+            foreach($argument in $Log.args) {
+                if($labels_given) {
+                    # labels are given, add the argument as a value and the label as the named index
+                    $allProperties.Add($Log.body.labels[$Log.args.IndexOf($argument)], $argument)
+                    # replace the messagetemplated e.g. {0} -> {named}
+                    $messageTemplate = $messageTemplate.replace("{$($Log.args.IndexOf($argument))}", "{$($Log.body.labels[$Log.args.IndexOf($argument)])}")
+                } else {
+                    # no labels are given, add the number as an argument so seq can handle the text correctly
+                    $allProperties.Add("$($Log.args.IndexOf($argument))", $argument)
+                }
+            }
+
+            # remove the labels, they have added to allProperties already
+            if($labels_given) {
+                $allProperties.body.Remove("labels")
+            }
+
+        } else {
+            $allProperties += @{ Text = $Log.Message; }
+        }
+
+        # if body is empty, remove it
+        if($allProperties.body.count -eq 0) {
+            $allProperties.Remove("body")
+        }
+
+        # exception handling
+        $exception = $null
+        if ($Log.ExecInfo) {
+            $exception = $Log.ExecInfo.ToString()
+            $exception += [System.Environment]::NewLine + $Log.ExecInfo.ScriptStackTrace
+        }
+
+        # use the 
+        $Body = @{
+            "Events" = @(
+                @{
+                    "Timestamp" = $Log.TimestampUtc
+                    "Level" = $Log.Level.substring(0,1).toupper()+$Log.Level.substring(1).tolower()
+                    "MessageTemplate" = $messageTemplate
+                    "Properties" = $allProperties
+                    "Exception" = $exception
+                }
+            )
+        }
+
+        $Body | ConvertTo-Json -Depth 5 | Out-File -FilePath C:\test.json
 
         if ($Configuration.ApiKey) {
-            $Url = '{0}/api/events/raw?clef&apiKey={1}' -f $Configuration.Url, $Configuration.ApiKey
+            $Url = '{0}/api/events/raw?apiKey={1}' -f $Configuration.Url, $Configuration.ApiKey
         }
         else {
-            $Url = '{0}/api/events/raw?clef' -f $Configuration.Url
+            $Url = '{0}/api/events/raw' -f $Configuration.Url
         }
 
-        Invoke-RestMethod -Uri $Url -Body ($Body | ConvertTo-Json -Compress) -Method POST | Out-Null
+        Invoke-RestMethod -Uri $Url -Body ($Body | ConvertTo-Json -Compress -Depth 5) -Method POST -ContentType "application/json" | Out-Null
     }
 }


### PR DESCRIPTION
# Pull Request


## Pull Request (PR) description
I fixed the SEQ integration and added support for labels.

Following Code: `Write-Log -Level 'WARNING' -Message 'Hello, {0}!' -Arguments 'Powershell'`

Before the Message was not converted correctly to the right text messages as it has not replaced the arguments
The Result was: 
![error_log](https://github.com/hanpq/PSLogs/assets/58696565/2dc139cd-def7-44d5-af65-679720cfbbd8)
detailed: 
![log_seq](https://github.com/hanpq/PSLogs/assets/58696565/1ace780b-1191-4ade-b895-f24669ac04d1)

The output in the console was fine: 
![output_powershell](https://github.com/hanpq/PSLogs/assets/58696565/3d654a92-a043-479f-b8f2-9b9aec31d4e6)


After the PR:
![matched_property_index](https://github.com/hanpq/PSLogs/assets/58696565/af576fcb-67df-48a7-a938-16f09cd4a0bb)
the message is rendered by seq and used the correct property based by index

I also added support for labels:
`Write-Log -Level 'DEBUG' -Message 'Hello, {0}!' -Arguments 'Powershell' -Body @{
    labels = @('scriptlanguage')
}`
It converts the messagetemplate send to seq to "Hello, {scriptlanguage}!" and gives them the correct properties.
![matched_property_named](https://github.com/hanpq/PSLogs/assets/58696565/cd9bbce3-5a2c-4c3b-8e07-220262175255)
the main advantage is that named labels are searchable in seq while searching for "0" gives a lot of results.


